### PR TITLE
Add Github to gem sources

### DIFF
--- a/data/Gemfile.aspen
+++ b/data/Gemfile.aspen
@@ -1,4 +1,5 @@
 source :rubygems
+source 'http://gems.github.com'
 
 # ruby
 ruby "1.8.7"


### PR DESCRIPTION
This will keep Bundler from failing for users who are using Github username-spaced gems.
